### PR TITLE
Clean specs

### DIFF
--- a/specs/jupyter.yaml
+++ b/specs/jupyter.yaml
@@ -1,12 +1,12 @@
 spec:
     containers:
     - name: "jupyter"
-      image: "<SNOWFLAKE_ACCOUNT>-<SNOWFLAKE_ORG>.registry.snowflakecomputing.com/<DATABASE>/<SCHEMA>/<IMAGE_REPO>/jupyter"
+      image: "<SNOWFLAKE_ACCOUNT>-<SNOWFLAKE_ORG>.registry.snowflakecomputing.com/weaviate_demo/public/weaviate_repo/jupyter"
       env:
         SNOWFLAKE_MOUNTED_STAGE_PATH: "stage"
         SNOW_ROLE: WEAVIATE_ROLE
         SNOW_WAREHOUSE: WEAVIATE_WAREHOUSE
-        SNOW_DATABASE: WEAVIATE_PRODUCT_REVIEWS
+        SNOW_DATABASE: WEAVIATE_DEMO
         SNOW_SCHEMA: PUBLIC
         SNOW_USER: WEAVIATE_USER
         SNOW_PASSWORD: weaviate123

--- a/specs/ollama.yaml
+++ b/specs/ollama.yaml
@@ -1,7 +1,7 @@
 spec:
   container:
   - name: ollama
-    image: "<SNOWFLAKE_ACCOUNT>-<SNOWFLAKE_ORG>.registry.snowflakecomputing.com/<DATABASE>/<SCHEMA>/<IMAGE_REPO>/ollama"
+    image: "<SNOWFLAKE_ACCOUNT>-<SNOWFLAKE_ORG>.registry.snowflakecomputing.com/weaviate_demo/public/weaviate_repo/ollama"
     volumeMounts:
       - name: stage
         mountPath: /workspace/stage
@@ -9,7 +9,7 @@ spec:
       LLM_MODEL: mistral
       SNOW_ROLE: WEAVIATE_ROLE
       SNOW_WAREHOUSE: WEAVIATE_WAREHOUSE
-      SNOW_DATABASE: WEAVIATE_PRODUCT_REVIEWS
+      SNOW_DATABASE: WEAVIATE_DEMO
       SNOW_SCHEMA: PUBLIC
       SNOW_USER: WEAVIATE_USER
       SNOW_PASSWORD: weaviate123

--- a/specs/text2vec.yaml
+++ b/specs/text2vec.yaml
@@ -1,7 +1,7 @@
 spec:
     containers:
     - name: "text2vec"
-      image: "<SNOWFLAKE_ACCOUNT>-<SNOWFLAKE_ORG>.registry.snowflakecomputing.com/<DATABASE>/<SCHEMA>/<IMAGE_REPO>/text2vec"
+      image: "<SNOWFLAKE_ACCOUNT>-<SNOWFLAKE_ORG>.registry.snowflakecomputing.com/weaviate_demo/public/weaviate_repo/text2vec"
       env:
         SNOWFLAKE_MOUNTED_STAGE_PATH: "stage"
         ENABLE_CUDA: 1
@@ -20,9 +20,5 @@ spec:
     - name: "text2vec"
       port: 8080
       public: true
-    volumes:
-    - name: data
-      source: "@data"
     - name: stage
       source: "@files"
-    

--- a/specs/weaviate.yaml
+++ b/specs/weaviate.yaml
@@ -1,7 +1,7 @@
 spec:
     containers:
     - name: "weaviate"
-      image: "<SNOWFLAKE_ACCOUNT>-<SNOWFLAKE_ORG>.registry.snowflakecomputing.com/<DATABASE>/<SCHEMA>/<IMAGE_REPO>/weaviate"
+      image: "<SNOWFLAKE_ACCOUNT>-<SNOWFLAKE_ORG>.registry.snowflakecomputing.com/weaviate_demo/public/weaviate_repo/weaviate"
       env:
         SNOWFLAKE_MOUNTED_STAGE_PATH: "stage"
         QUERY_DEFAULTS_LIMIT: 25
@@ -12,7 +12,6 @@ spec:
         CLUSTER_HOSTNAME: 'node1'
         ENABLE_MODULES: 'text2vec-transformers,generative-openai'
         TRANSFORMERS_INFERENCE_API: 'http://text2vec:8080'
-        
       volumeMounts:
         - name: stage
           mountPath: /workspace/stage


### PR DESCRIPTION
Since we now have a consistent DB name (`WEAVIATE_DEMO`), image URLs and environment variables can be updated to include the full repository path. Users only have to update the `<SNOWFLAKE_ACCOUNT>-<SNOWFLAKE_ORG>` for images.

Updated `SNOW_DATABASE` environment variables to `WEAVIATE_DEMO` where applicable.

Removed unused stage (`@data`) in text2vec spec.

Added new lines to ends of files.